### PR TITLE
Golden Goblet will be found in catacombs

### DIFF
--- a/data/harvestable.yaml
+++ b/data/harvestable.yaml
@@ -6,6 +6,7 @@ catacombs:
     slime: 0.2
     treasure_chest: 0.1
     giant_rat: 0.1
+    golden_goblet: 0
   time: 60
 forest:
   cards:


### PR DESCRIPTION
Kinda incomplete since you find it exactly with the 4th exploration (and the catacombs vanish after the 5th, same as the cave for the treasure map) but not sure there's currently a way to represent that so added it the same way the treasure map is currently handled.